### PR TITLE
Improve optional debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ To contribute to this project:
 4. Test thoroughly
 5. Submit a pull request
 
+## Debugging
+The application includes an optional enhanced debugging system. To enable it,
+set `window.DEBUG_MODE = true` or save `enableDebug=true` in `localStorage`
+before loading the page. When enabled, a diagnostic panel and verbose console
+logs will help troubleshoot loading issues.
+
 ## License
 © 2025 Portnox Ltd. All Rights Reserved.
 

--- a/js/enhancements/enhanced-debugging.js
+++ b/js/enhancements/enhanced-debugging.js
@@ -386,10 +386,26 @@ class EnhancedDebugging {
 }
 
 // Initialize debugging system
+// Initialize debugging system when explicitly enabled
 document.addEventListener('DOMContentLoaded', function() {
-    if (!window.enhancedDebugging) {
-        window.enhancedDebugging = new EnhancedDebugging();
-        window.enhancedDebugging.init();
+    const debugEnabled = window.DEBUG_MODE === true ||
+        localStorage.getItem('enableDebug') === 'true';
+
+    if (debugEnabled) {
+        if (!window.enhancedDebugging) {
+            window.enhancedDebugging = new EnhancedDebugging();
+            window.enhancedDebugging.init();
+        }
+    } else {
+        // Provide lightweight stub to avoid errors when debugging is disabled
+        if (!window.enhancedDebugging) {
+            window.enhancedDebugging = {
+                log() {}, debug() {}, info() {}, warn() {}, error() {}, success() {},
+                monitorChartLoading() {}, monitorTabLoading() {},
+                monitorDataLoading() {}, monitorVendorSelection() {},
+                generateDiagnosticReport() { return {}; }
+            };
+        }
     }
 });
 


### PR DESCRIPTION
## Summary
- add optional debug initialization stub
- document debug flag in README

## Testing
- `npm test` *(fails: no test specified)*