### PR TITLE
Fix missing VendorDatabase loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,10 @@
         };
     </script>
     
+    <!-- Core Scripts -->
+    <script src="./js/core/module-loader.js"></script>
+    <script src="./js/core/module-loader-init.js"></script>
+
     <!-- Core Data -->
     <script src="./js/data/vendor-database.js"></script>
     <script src="./js/data/industry-database.js"></script>


### PR DESCRIPTION
## Summary
- load the module loader before vendor data

## Testing
- `bash verify_tco.sh`

------
https://chatgpt.com/codex/tasks/task_b_6844c53087108328b5ab556c31911dcf